### PR TITLE
Hotfix for pip requirements not installing unless named requirements-local

### DIFF
--- a/docker/docker-bootstrap.sh
+++ b/docker/docker-bootstrap.sh
@@ -19,6 +19,8 @@
 set -eo pipefail
 
 REQUIREMENTS_LOCAL="/app/docker/requirements-local.txt"
+REQUIREMENTS_ADDONS="/app/docker/requirements-addons.txt"
+
 # If Cypress run – overwrite the password for admin and export env variables
 if [ "$CYPRESS_CONFIG" == "true" ]; then
     export SUPERSET_CONFIG=tests.integration_tests.superset_test_config
@@ -31,6 +33,13 @@ fi
 if [ -f "${REQUIREMENTS_LOCAL}" ]; then
   echo "Installing local overrides at ${REQUIREMENTS_LOCAL}"
   pip install -r "${REQUIREMENTS_LOCAL}"
+fi
+#
+# Install any additional pip dependencies for your build
+#
+if [ -f "${REQUIREMENTS_ADDONS}" ]; then
+  echo "Installing additional dependencies at ${REQUIREMENTS_ADDONS}"
+  pip install -r "${REQUIREMENTS_ADDONS}"
 fi
 
 # To run the following redis connection checks, you first must install one of


### PR DESCRIPTION
This hotfix addresses an issue where the Docker bootstrap script is not installing deps in the `requirements-addons.txt` file. The  cause was the late hour renaming of `requirements-local` to `requirements-addons`, causing the Docker script to miss building the added dependencies. 