### PR TITLE
Upgrade to Superset 3.0.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # If you need to run locally, see the apache/superset Git repo instead.
 #
-FROM apache/superset:2.1.1
+FROM apache/superset:3.0.2
 
 COPY --chown=superset ./docker/docker-bootstrap.sh /app/docker/
 COPY --chown=superset ./docker/docker-init.sh /app/docker/

--- a/README.md
+++ b/README.md
@@ -51,13 +51,13 @@ First you must commit to a specific release version of Superset, and
 
 - update that version in [`Dockerfile`](Dockerfile)
 - port any new changes to `superset_config.py` from that same tag upstream. This is manual and will require some diffing, something like:
-  - cd ~/dev/superset ; git checkout 2.1.1
+  - cd ~/dev/superset ; git checkout 3.0.2
   - diff ~/dev/superset/docker/pythonpath_dev/superset_config.py ~/dev/superset-deployment/docker/pythonpath/superset_config.py
 
 Now you can build the image, and might as well push it to the container registry too:
 
 ```bash
-SS_VERSION=2.1.1
+SS_VERSION=3.0.2
 BUILD=$(date +"%Y%m%d-%H%M")
 OUR_TAG="${SS_VERSION}_${BUILD}"
 docker build -t guardiancr.azurecr.io/superset-docker:${OUR_TAG} .
@@ -120,7 +120,7 @@ However App Service will kill after a couple minutes if it hasn't found a web se
 The web service exposing port 8080 needs to be the _first_ service listed in a multi-container app! (This is not documented; we should report a bug to Azure...).  If instead you put `superset-init` first, App Service will kill it.
 
 ```yaml
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:2.1.1_20230928-1744
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"
@@ -152,7 +152,7 @@ even longer if your PostgreSQL instance is Burstable. Tail the logs (as shown ab
 Remove the `superset-init` service. Replace the maintenance page with the actual Superset web service. Add Celery worker and beat.
 
 ```yaml
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:2.1.1_20230928-1744
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:2.1.1_20231012-1306
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -96,8 +96,18 @@ class CeleryConfig(object):
         },
     }
 
-
 CELERY_CONFIG = CeleryConfig
+
+# CSP settings as provided by the Talisman extension
+# See https://superset.apache.org/docs/security/#content-security-policy-csp
+TALISMAN_CONFIG = {
+    "force_https": False,
+    "content_security_policy": {
+        "img-src": "*",
+        "media-src": "*",
+        "frame-ancestors": ["'self'", "https://*.guardianconnector.net"]    
+    }
+}
 
 # https://github.com/apache/superset/blob/master/RESOURCES/FEATURE_FLAGS.md
 FEATURE_FLAGS = { "ALERT_REPORTS": True}
@@ -109,7 +119,6 @@ WEBDRIVER_BASEURL_USER_FRIENDLY = WEBDRIVER_BASEURL
 SQLLAB_CTAS_NO_LIMIT = True
 
 # Custom config for biocultural monitoring deployments by CMI
-
 AUTH0_DOMAIN = get_env_variable("AUTH0_DOMAIN")
 
 # Extend the default AuthOAuthView to override the default message when the user is not authorized
@@ -192,6 +201,7 @@ OAUTH_PROVIDERS = [{
 LANGUAGES = json.loads(get_env_variable("LANGUAGES", {}))
 MAPBOX_API_KEY = get_env_variable("MAPBOX_API_KEY")
 
+# Sanitization settings to allow iframes and style tags in markdown
 HTML_SANITIZATION_SCHEMA_EXTENSIONS = {
   "attributes": {
     "*": ["style","className","src","width","height","frameborder","marginwidth","marginheight","scrolling"],


### PR DESCRIPTION
This PR updates our deployment's version of Superset to 3.0.2. 

It pretty much works fine without any issues out of the box. I tested a 3.0.2 build on all of our deployments and they all work fine, with the exception that Superset 3.x.x forces a CSP by default now, which is a good thing anyway (and hence closes https://github.com/ConservationMetrics/superset-deployment/issues/2). So the other thing I had to do here was apply some CSP settings in Talisman to get our customizations (e.g. embedding of images, iframes) working.