### PR TITLE
Translate flashed messages (and add one) for authentication flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ First you must commit to a specific release version of Superset, and
 Now you can build the image, and might as well push it to the container registry too:
 
 ```bash
-SS_VERSION=3.0.2
+SS_VERSION=3.0.3
 BUILD=$(date +"%Y%m%d-%H%M")
 OUR_TAG="${SS_VERSION}_${BUILD}"
 docker build -t guardiancr.azurecr.io/superset-docker:${OUR_TAG} .

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240605-1556
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -123,6 +123,11 @@ AUTH0_DOMAIN = get_env_variable("AUTH0_DOMAIN")
 
 # Extend the default AuthOAuthView to override the default message when the user is not authorized
 class CustomAuthOAuthView(AuthOAuthView):
+    @expose("/login")
+    def login(self) -> WerkzeugResponse:
+        flash("Welcome! Please sign up or log in with Auth0 below to access the application.", "info")
+        return super().login()
+
     @expose("/oauth-authorized/<provider>")
     def oauth_authorized(self, provider: str) -> WerkzeugResponse:
         response = super().oauth_authorized(provider)
@@ -193,7 +198,6 @@ OAUTH_PROVIDERS = [{
         'api_base_url':f'https://{AUTH0_DOMAIN}/oauth/',
         'access_token_url': f'https://{AUTH0_DOMAIN}/oauth/token',
         'authorize_url': f'https://{AUTH0_DOMAIN}/authorize'
-
     }
 }]
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -30,7 +30,7 @@ from flask_appbuilder.security.manager import AUTH_OAUTH
 from flask_appbuilder.security.views import AuthOAuthView
 from flask_appbuilder import expose
 from flask import flash, get_flashed_messages
-from flask_babel import gettext as _, get_locale
+from flask_babel import get_locale
 from werkzeug.wrappers import Response as WerkzeugResponse
 
 from superset.security import SupersetSecurityManager
@@ -123,12 +123,12 @@ AUTH0_DOMAIN = get_env_variable("AUTH0_DOMAIN")
 
 # Define translations
 translations = {
-    "Welcome! Please sign up or log in with Auth0 below to access the application.": {
-        "pt_BR": "Bem-vindo! Por favor, inscreva-se ou faça login com Auth0 abaixo para acessar o aplicativo.",
-        "en": "Welcome! Please sign up or log in with Auth0 below to access the application.",
-        "nl": "Welkom! Meld u aan of log in met Auth0 hieronder om toegang te krijgen tot de applicatie.",
-        "es": "¡Bienvenido! Regístrese o inicie sesión con Auth0 a continuación para acceder a la aplicación.",
-        "fr": "Bienvenue! Veuillez vous inscrire ou vous connecter avec Auth0 ci-dessous pour accéder à l'application."
+    "Welcome! Please sign up or log in by pressing 'Sign in with auth0' to access the application": {
+        "pt_BR": "Bem-vindo! Por favor, inscreva-se ou faça login pressionando 'Sign in with auth0' para acessar o aplicativo.",
+        "en": "Welcome! Please sign up or log in by pressing 'Sign in with auth0' to access the application",
+        "nl": "Welkom! Meld u aan of log in door op 'Sign in with auth0' te drukken om toegang te krijgen tot de applicatie.",
+        "es": "¡Bienvenido! Regístrese o inicie sesión presionando 'Sign in with auth0' para acceder a la aplicación.",
+        "fr": "Bienvenue! Veuillez vous inscrire ou vous connecter en appuyant sur 'Sign in with auth0' pour accéder à l'application."
     },
     "The request to sign in was denied.": {
         "pt_BR": "O pedido de login foi negado.",
@@ -154,7 +154,7 @@ def translate(message):
 class CustomAuthOAuthView(AuthOAuthView):
     @expose("/login")
     def login(self) -> WerkzeugResponse:
-        flash(translate("Welcome! Please sign up or log in with Auth0 below to access the application."), "info")
+        flash(translate("Welcome! Please sign up or log in by pressing 'Sign in with auth0' to access the application"), "info")
         return super().login()
 
     @expose("/oauth-authorized/<provider>")


### PR DESCRIPTION
I have observed recently that some new users are unsure of what to do when they open the Superset `/login` page; it's not obvious to them that "Sign in with auth0" encompasses both signing up and logging in. I have therefore added a "welcome" message with helpful information about signing up or logging in to be flashed at the top of the page.

In the same stroke, I have added translations for all of the messages flashed by `CustomAuth0AuthView`. The translations include all of the currently supported (by us) languages in Superset - en, pt_BR, nl, es, fr.

![image](https://github.com/ConservationMetrics/superset-deployment/assets/31662219/faf6a281-2377-45d8-9dff-3c5e392dd159)