### PR TITLE
Add optional env vars for dashboard and user role customization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,9 @@ RUN pip install --no-cache-dir -r /app/docker/requirements-addons.txt
 
 # This script is what sets config values from environment variables.
 COPY --chown=superset ./docker/pythonpath/superset_config.py /app/pythonpath/
-ENV PYTHONPATH "${PYTHONPATH}:/app/pythonpath/"
+ENV PYTHONPATH="${PYTHONPATH}:/app/pythonpath/"
 
-ENV FLASK_ENV production
-ENV SUPERSET_ENV production
+ENV FLASK_ENV=production
+ENV SUPERSET_ENV=production
 
 RUN chmod a+x /app/docker/*.sh

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ First you must commit to a specific release version of Superset, and
 
 - update that version in [`Dockerfile`](Dockerfile)
 - port any new changes to `superset_config.py` from that same tag upstream. This is manual and will require some diffing, something like:
-  - cd ~/dev/superset ; git checkout 3.0.2
+  - cd ~/dev/superset ; git checkout 3.0.3
   - diff ~/dev/superset/docker/pythonpath_dev/superset_config.py ~/dev/superset-deployment/docker/pythonpath/superset_config.py
 
 Now you can build the image, and might as well push it to the container registry too:
@@ -123,7 +123,7 @@ However App Service will kill after a couple minutes if it hasn't found a web se
 The web service exposing port 8080 needs to be the _first_ service listed in a multi-container app! (This is not documented; we should report a bug to Azure...).  If instead you put `superset-init` first, App Service will kill it.
 
 ```yaml
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240710-1314
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"
@@ -155,7 +155,7 @@ even longer if your PostgreSQL instance is Burstable. Tail the logs (as shown ab
 Remove the `superset-init` service. Replace the maintenance page with the actual Superset web service. Add Celery worker and beat.
 
 ```yaml
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.2_20231215-0854
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240710-1314
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"
@@ -201,6 +201,15 @@ We are using auth0 for authentication. For auth0 to work, you will need to provi
 The starting Role of the user once approved is determined by a `USER_ROLE` environmental variable. Please see [this guide on Superset roles](https://superset.apache.org/docs/security/) to set the appropriate starting Role for your deployment. The fallback value is "Gamma" if the var is not set.
 
 Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using environmental variables to create an admin user whose username should match your auth0 email account.
+
+## Optional environmental variables
+
+To allow for flexible customization, we have provided several optional environmental variables (commented out in `.env.sample`):
+
+* `APP_NAME`: if you want the page title for the dashboard to be something different than "Superset"
+* `APP_ICON`: to change the Superset logo shown on the top left of the window.
+* `USER_ROLE_PERMISSIONS`: if you want to assign additional permissions to the Starting role of a user once approved as defined in `USER_ROLE`.
+* `FRAME_ANCESTORS`: to provide a comma separated list of permissible frame ancestors for your CSP.
 
 ## Superset setup
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ To allow for flexible customization, we have provided several optional environme
 
 * `APP_NAME`: if you want the page title for the dashboard to be something different than "Superset"
 * `APP_ICON`: to change the Superset logo shown on the top left of the window.
-* `USER_ROLE_PERMISSIONS`: if you want to assign additional permissions to the Starting role of a user once approved as defined in `USER_ROLE`.
+* `USER_ROLE_PERMISSIONS`: if you want to assign additional permissions to the Starting role of a user once approved as defined in `USER_ROLE`. Note that setting these means that any changes made to the permissions for that user role (e.g. in the Superset UI) will be overwritten upon deployment of the application.
 * `FRAME_ANCESTORS`: to provide a comma separated list of permissible frame ancestors for your CSP.
 
 ## Superset setup

--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240605-1556
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240710-1314
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -1,10 +1,15 @@
 COMPOSE_PROJECT_NAME=superset
 SECRET_KEY="TODO: openssl rand -base64 42 "
 
+# Optionally, set the application name and logo for the header. Default Superset
+# settings will be used if not set here.
+# APP_NAME = "Your Superset application name"
+# APP_ICON = "URL (relative or absolute) to the application logo"
+
 # Admin user is created during initialization. Authentication will be handled by Auth0
 # using the username, which should match the email address of the auth0 user.
-ADMIN_EMAIL=admin@guardianconnector.net
-ADMIN_USERNAME=admin@guardianconnector.net
+ADMIN_EMAIL=admin@yourdomain.net
+ADMIN_USERNAME=admin@yourdomain.net
 ADMIN_PASSWORD="TODO"
 
 # database configurations
@@ -21,6 +26,8 @@ AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
 
 # Superset user registration config
 USER_ROLE="Gamma"
+# Optional, comma-separated list "(),(),()..." of valid permissions for your user role
+# USER_ROLE_PERMISSIONS="(can_read,Chart),(all_datasource_access),(all_database_access),(all_query_access)"
 
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
 MAPBOX_API_KEY="YOUR MAP KEY HERE"
@@ -29,3 +36,6 @@ MAPBOX_API_KEY="YOUR MAP KEY HERE"
 # SUPERSET_LOAD_EXAMPLES=false
 # CYPRESS_CONFIG=false
 # SUPERSET_PORT=8088
+
+# Optionally, for CSP, you can configure a comma separated list of frame ancestors
+# FRAME_ANCESTORS="https://*.yourdomain.net,https://anotherdomain.net"


### PR DESCRIPTION
Closes #9, #22, and #30.

This PR introduces a few optional environmental variables (`APP_NAME`, `APP_ICON`, `USER_ROLE_PERMISSIONS`, and `FRAME_ANCESTORS`) that are implemented in the Superset `config.py`, with fallback values to default Superset config if they are not set.

* It's now possible to change the page title and Superset logo in the app.
* Now, you can set frame ancestors for CSP (previously, they were hard coded).
* You can provide a list of user permissions to supply for the default registration user role.
* All of this is described in the README and `.env.sample` file.

Lastly, I've made a few small fixes here and there. I will point these out in comments.