### PR TITLE
Fix: better handling of permission tuples, and correct env examples

### DIFF
--- a/docker-compose-non-dev.yml
+++ b/docker-compose-non-dev.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240710-1314
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:3.0.3_20240829-1117
 x-superset-depends-on: &superset-depends-on []
 
 version: "3.7"

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -27,7 +27,7 @@ AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
 # Superset user registration config
 USER_ROLE="Gamma"
 # Optional, comma-separated list "(),(),()..." of valid permissions for your user role
-# USER_ROLE_PERMISSIONS="(can_read,Chart),(all_datasource_access),(all_database_access),(all_query_access)"
+# USER_ROLE_PERMISSIONS="(can_read,Chart),(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
 
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
 MAPBOX_API_KEY="YOUR MAP KEY HERE"

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -26,8 +26,19 @@ AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
 
 # Superset user registration config
 USER_ROLE="Gamma"
-# Optional, comma-separated list "(),(),()..." of valid permissions for your user role
+
+# Optional, comma-separated list of "(),(),()..." of valid permissions for your user role.
+# Each tuple is a 2-tuple: (permission_name, view_name).
 # USER_ROLE_PERMISSIONS="(can_read,Chart),(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
+# 
+# For more about permissions, refer to the Superset documentation:
+# https://superset.apache.org/docs/security/#customizing-permissions
+# https://incubator-superset.readthedocs.io/en/latest/security.html
+#
+# Please note that global permissions that don't apply to a single view 
+# such as 'all_datasource_access' need to still be in a 2-tuple format
+# with the user role permission repeated instead of the view name
+# e.g. (all_datasource_access,all_datasource_access)
 
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
 MAPBOX_API_KEY="YOUR MAP KEY HERE"

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -213,7 +213,7 @@ class CustomSecurityManager(SupersetSecurityManager):
                             logger.info(f"Adding permission {pvm} to role {user_role}")
                             self.add_permission_role(user_role, pvm)
                     else:
-                        logger.info("Permission is not a tuple. Skipping...")
+                        logger.warning("Permission is not a 2-tuple. Skipping...")
 
 
     def oauth_user_info(self, provider, response=None):


### PR DESCRIPTION
Closes #33. Permissions are always a tuple and the format for the respective ones that were breaking is `('all_datasource_access','all_datasource_access')` (as now correctly noted in the env example file).

Now, if the permissions are not formatted correctly, they will be skipped.