### PR TITLE
Bump to newer version of authlib

### DIFF
--- a/docker/requirements-addons.txt
+++ b/docker/requirements-addons.txt
@@ -1,1 +1,1 @@
-authlib~=1.2.1
+authlib>=1.3.1,<2


### PR DESCRIPTION
Resolve this security alert: https://github.com/ConservationMetrics/superset-deployment/security/dependabot/1

![image](https://github.com/user-attachments/assets/7c1c43fe-9f65-4bfc-ac0f-a0f7aeef0b06)

