### PR TITLE
Document Caprover install using one-click-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Deploy Superset using Docker Compose
+# Deploy Superset using CapRover or Docker Compose
 
 [Apache Superset](https://github.com/apache/superset/) is a data exploration and data visualization platform.
 
@@ -6,7 +6,7 @@ The project's technical documentation makes it easy to get up-and-running locall
 laptop), but does not support a dockerized production deployment. Instead they recommend using helm,
 either on a Kubernetes cluster or a single VM using minikube.
 
-This `superset-deployment` helps you deploy Superset for production using **docker compose**.
+This `superset-deployment` helps you deploy Superset for production using **docker compose** or [**CapRover**](https://caprover.com/).
 
 ## Hardware & Infrastructure
 
@@ -72,10 +72,19 @@ more comfortable environment.
 2. Put environment variables in a new file called `docker/.env`
    - you may first `cp docker/.env-sample docker/.env`
    - make sure `DATABASE_URI` and `REDIS_URL` point to non-production services (assuming you want that)
-3. `docker-compose up`. Note that `superset-init` takes a few minutes to complete (it will terminate once done), and the rest of the app is unusable/buggy until then.
+3. `docker compose up`. Note that `superset-init` takes a few minutes to complete (it will terminate once done), and the rest of the app is unusable/buggy until then.
 4. Open a browser to [`localhost:8088`](http://localhost:8088)
 
 ### Running in Production
+
+Using **CapRover**:
+- install superset using the [one-click app](./caprover/one-click-apps/README.md)
+
+Using **docker compose**
+- Run `docker compose up`
+
+
+#### Prerequisites
 
 Your VM should have at least 4GB RAM (The official guidance from Apache is 8GB but I've never had a problem with only 4GB).
 
@@ -139,3 +148,5 @@ add it to the `command` of one of the Docker services:
 ```yaml
     command: sh -c "superset db upgrade ; /app/docker/docker-boostrap beat"
 ```
+
+The one-click app for CapRover already includes this in its `init-and-beat` service.

--- a/caprover/one-click-apps/README.md
+++ b/caprover/one-click-apps/README.md
@@ -1,0 +1,27 @@
+This folder contains the custom Superset deployment as a [CapRover one-click app](https://caprover.com/docs/one-click-apps.html).
+
+
+### Add this repo to your CapRover deployment
+
+In order to add a third party repository:
+-   Login to your CapRover dashboard
+-   Go to **apps** and click on **One-Click Apps/Databases** and scrolldown to the bottom
+-   Under **3rd party repositories:** copy  the URL, (for example: `https://Awes0meHub.github.io/caprover-one-click-apps`) and paste it in to the text box
+-   Click the **_Connect New Repository_** button
+
+### Install from this repo using Caprover-API
+
+You can skip the "add this repo" step shown above yet still install
+Superset from this repo, using the Python [Caprover-API](https://github.com/ak4zh/Caprover-API/):
+
+```python
+
+cap.deploy_one_click_app(
+    "superset",
+    "superset",
+    app_variables=variables,
+    automated=True,
+    one_click_repository=XXX,
+)
+```
+

--- a/caprover/one-click-apps/README.md
+++ b/caprover/one-click-apps/README.md
@@ -6,7 +6,7 @@ This folder contains the custom Superset deployment as a [CapRover one-click app
 In order to add a third party repository:
 -   Login to your CapRover dashboard
 -   Go to **apps** and click on **One-Click Apps/Databases** and scrolldown to the bottom
--   Under **3rd party repositories:** copy  the URL, (for example: `https://Awes0meHub.github.io/caprover-one-click-apps`) and paste it in to the text box
+-   Under **3rd party repositories:** copy  the URL, (for example: `https://conservationmetrics.github.io/superset-deployment/caprover/one-click-apps/`) and paste it in to the text box
 -   Click the **_Connect New Repository_** button
 
 ### Install from this repo using Caprover-API
@@ -15,13 +15,15 @@ You can skip the "add this repo" step shown above yet still install
 Superset from this repo, using the Python [Caprover-API](https://github.com/ak4zh/Caprover-API/):
 
 ```python
+from caprover_api import caprover_api
 
+cap = caprover_api.CaproverAPI(
+    dashboard_url="cap-dashboard-url",
+    password="cap-dashboard-password"
+)
 cap.deploy_one_click_app(
-    "superset",
-    "superset",
-    app_variables=variables,
-    automated=True,
-    one_click_repository=XXX,
+    one_click_app_name="superset-only",
+    one_click_repository="https://conservationmetrics.github.io/superset-deployment/caprover/one-click-apps/"
 )
 ```
 

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -1,0 +1,137 @@
+captainVersion: 4
+
+
+services:
+  $$cap_appname:
+    image: $$cap_superset_docker_image
+    command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
+    restart: unless-stopped
+    depends_on:
+      - $$cap_appname-init-and-beat
+    environment:
+      SECRET_KEY: $$cap_secret_key
+      REDIS_URL: $$cap_redis_url
+      CACHE_KEY_PREFIX: $$cap_redis_key_prefix
+      DATABASE_URI: postgresql://$$cap_postgres_userpassword@$$cap_postgres_host:$$cap_postgres_port/superset_metastore
+      AUTH0_DOMAIN: $$cap_auth0_domain
+      AUTH0_CLIENTID: $$cap_auth0_clientid
+      AUTH0_CLIENT_SECRET: $$cap_auth0_client_secret
+      MAPBOX_API_KEY: $$cap_mapbox_api_key
+      APP_ICON: $$cap_app_icon
+      APP_NAME: $$cap_app_title
+      USER_ROLE: Gamma
+      USER_ROLE_PERMISSIONS: "(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
+      LANGUAGES: "{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
+      FRAME_ANCESTORS: "https://*.guardianconnector.net"
+    caproverExtra:
+      containerHttpPort: '8088'
+
+  $$cap_appname-worker:
+    command: ["/app/docker/docker-bootstrap.sh", "worker"]
+    restart: unless-stopped
+    depends_on:
+      - $$cap_appname-init-and-beat
+    environment:
+      SECRET_KEY: $$cap_secret_key
+      REDIS_URL: $$cap_redis_url
+      CACHE_KEY_PREFIX: $$cap_redis_key_prefix
+      DATABASE_URI: postgresql://$$cap_postgres_userpassword@$$cap_postgres_host:$$cap_postgres_port/superset_metastore
+    caproverExtra:
+      notExposeAsWebApp: 'true'
+      dockerfileLines:
+        - FROM $$cap_superset_docker_image
+        - HEALTHCHECK NONE  # otherwise Docker keeps restarting this container when it doesn't respond on port 8088
+
+  $$cap_appname-init-and-beat:
+    healthcheck:  # FIXME: This doesn't do anything for caprover, but need to remove the HEALTHCHECK from the Docker image...
+      disable: true
+    # We also run init here because if init was its own service, caprover would continually restart it after it finishes.
+    command: >
+      sh -c "
+        /app/docker/docker-init.sh ;
+        superset db upgrade ;
+        /app/docker/docker-bootstrap.sh beat
+      "
+    restart: unless-stopped
+    environment:
+      SECRET_KEY: $$cap_secret_key
+      REDIS_URL: $$cap_redis_url
+      CACHE_KEY_PREFIX: $$cap_redis_key_prefix
+      DATABASE_URI: postgresql://$$cap_postgres_userpassword@$$cap_postgres_host:$$cap_postgres_port/superset_metastore
+      # For init only:
+      ADMIN_EMAIL: admin@guardianconnector.net
+      ADMIN_PASSWORD: $$cap_gen_random_hex(64)
+    caproverExtra:
+      notExposeAsWebApp: 'true'
+      dockerfileLines:
+        - FROM $$cap_superset_docker_image
+        - HEALTHCHECK NONE  # otherwise Docker keeps restarting this container when it doesn't respond on port 8088
+
+
+caproverOneClickApp:
+  variables:
+    - id: '$$cap_superset_docker_image'
+      label: Superset Docker Image
+      defaultValue: 'guardiancr.azurecr.io/superset-docker:3.1.3_20241106-1040'
+      description: Check out the container registry for valid tags
+    - id: '$$cap_secret_key'
+      label: Superset Secret Key
+      defaultValue: '$$cap_gen_random_hex(100)'
+      description: Used to encrypt secrets in the Database. Changing this may result in some old data not being readable.
+
+    - id: '$$cap_postgres_host'
+      label: Postgres service host name
+      defaultValue: 'srv-captain--postgres'
+      description: Copy the value from /#/apps/details/postgres
+    - id: '$$cap_postgres_port'
+      label: Postgres service port
+      defaultValue: '5432'
+    - id: '$$cap_postgres_userpassword'
+      label: Postgres user:password
+      validRegex: /:/
+      description: user:password, copy the values from /#/apps/details/postgres
+
+    # TODO: allow to run redis on local VM
+    - id: '$$cap_redis_url'
+      label: Redis URL
+    - id: '$$cap_redis_key_prefix'
+      label: Redis key prefix
+      defaultValue: '$$cap_gen_random_hex(3)_'
+      description: optional, used when multiple deployments share the same Redis URL
+
+    - id: '$$cap_auth0_domain'
+      label: Auth0 Domain
+      description: optional, to login using Auth0
+    - id: '$$cap_auth0_clientid'
+      label: Auth0 Client ID
+      description: optional, to login using Auth0
+    - id: '$$cap_auth0_client_secret'
+      label: Auth0 Client Secret
+      description: optional, to login using Auth0
+
+    - id: '$$cap_mapbox_api_key'
+      label: Mapbox API key
+      description: optional, to use mapbox maps, see https://docs.mapbox.com/help/getting-started/access-tokens/
+    - id: '$$cap_app_icon'
+      label: App Icon
+      description: a URL to an image
+    - id: '$$cap_app_title'
+      label: App Title
+      description: Shown on the top of the site
+
+  instructions:
+    start: |-
+        Apache Superset is a data exploration and data visualization platform.
+
+        This requires you to have the PostgreSQL database and Redis cache already deployed:
+        either externally via a cloud provider, or on this same instance as a One-Click App
+    end: |-
+        Superset is deploying and will be available within a minute.
+
+        Next steps:
+        1. Login at http://$$cap_appname.$$cap_root_domain
+        2. Add the data warehouse as a new Data Store
+  displayName: Superset
+  isOfficial: false  # Only if all images used here are official or from a trusted source.
+  description: Apache Superset is a data exploration and data visualization platform.
+  documentation: https://github.com/ConservationMetrics/superset-deployment

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -95,7 +95,6 @@ caproverOneClickApp:
       validRegex: /:/
       description: user:password, copy the values from /#/apps/details/postgres
 
-    # TODO: allow to run redis on local VM
     - id: '$$cap_redis_url'
       label: Redis URL
     - id: '$$cap_redis_key_prefix'
@@ -133,8 +132,16 @@ caproverOneClickApp:
         Superset is deploying and will be available within a minute.
 
         Next steps:
-        1. Login at http://$$cap_appname.$$cap_root_domain
-        2. Add the data warehouse as a new Data Store
+
+        1. On $$cap_appname-worker and $$cap_appname-init-and-beat, add the following lines to the
+        bottom of "Service Update Override" on the "App Config" page:
+        ```
+        HealthCheck:
+          Test: ["NONE"]
+        ```
+
+        2. Login at http://$$cap_appname.$$cap_root_domain
+        3. Add the data warehouse as a new Data Store
   displayName: Superset
   isOfficial: false  # Only if all images used here are official or from a trusted source.
   description: Apache Superset is a data exploration and data visualization platform.

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -59,7 +59,7 @@ services:
       CACHE_KEY_PREFIX: $$cap_redis_key_prefix
       DATABASE_URI: postgresql://$$cap_postgres_userpassword@$$cap_postgres_host:$$cap_postgres_port/superset_metastore
       # For init only:
-      ADMIN_EMAIL: admin@guardianconnector.net
+      ADMIN_EMAIL: $$cap_superset_admin_email
       ADMIN_PASSWORD: $$cap_gen_random_hex(64)
     caproverExtra:
       notExposeAsWebApp: 'true'
@@ -74,6 +74,10 @@ caproverOneClickApp:
       label: Superset Docker Image
       defaultValue: 'guardiancr.azurecr.io/superset-docker:4.1.1_20250203-1852'
       description: Check out the container registry for valid tags
+    - id: '$$cap_superset_admin_email'
+      label: Email for Superset admin user
+      validRegex: /^([^\s^\/])+$/
+      description: optional, used when multiple deployments share the same Redis URL
     - id: '$$cap_secret_key'
       label: Superset Secret Key
       defaultValue: '$$cap_gen_random_hex(100)'

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -72,7 +72,7 @@ caproverOneClickApp:
   variables:
     - id: '$$cap_superset_docker_image'
       label: Superset Docker Image
-      defaultValue: 'guardiancr.azurecr.io/superset-docker:3.1.3_20241106-1040'
+      defaultValue: 'guardiancr.azurecr.io/superset-docker:4.1.1_20250203-1852'
       description: Check out the container registry for valid tags
     - id: '$$cap_secret_key'
       label: Superset Secret Key


### PR DESCRIPTION
Brings one-click-app definition for our superset deployment into this repo.

#### What I changed

1. Port one-click app defn from `gc-forge`.
    a. bump docker version
    b. parameterize ADMIN_EMAIL

3. Enable github pages on this repo. This creates the public URL that any caprover install can use to install our build of superset as a one-click app: https://conservationmetrics.github.io/superset-deployment/caprover/one-click-apps/