### PR TITLE
Simplify redis cache config

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ either on a Kubernetes cluster or a single VM using minikube.
 
 This `superset-deployment` helps you deploy Superset for production using **docker compose**.
 
+It also takes an opinionated approach that it will be deployed with:
+- Auth0 login
+- Postgresql for the database
+- Redis for the cache
+
 ## Hardware & Infrastructure
 
 Superset is a multi-container deployment, comprising

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250204-1000
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250204-1032
 
 services:
   superset:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250203-1852
-x-superset-depends-on: &superset-depends-on []
 
 services:
   superset:
@@ -13,7 +12,9 @@ services:
     restart: unless-stopped
     ports:
       - "8088:8088"
-    depends_on: *superset-depends-on
+    depends_on:
+      redis:
+        condition: service_healthy
 
   superset-init:
     env_file:
@@ -23,7 +24,6 @@ services:
     container_name: superset_init
     command: ["/app/docker/docker-init.sh"]
     user: "root"
-    depends_on: *superset-depends-on
 
   superset-worker:
     env_file:
@@ -34,7 +34,9 @@ services:
     command: ["/app/docker/docker-bootstrap.sh", "worker"]
     user: "root"
     restart: unless-stopped
-    depends_on: *superset-depends-on
+    depends_on:
+      redis:
+        condition: service_healthy
 
   superset-worker-beat:
     env_file:
@@ -45,7 +47,9 @@ services:
     command: ["/app/docker/docker-bootstrap.sh", "beat"]
     user: "root"
     restart: unless-stopped
-    depends_on: *superset-depends-on
+    depends_on:
+      redis:
+        condition: service_healthy
 
   # db:
   #   env_file: docker/.env
@@ -59,6 +63,15 @@ services:
   #     - POSTGRES_USER=circleci
   #     - POSTGRES_PASSWORD=C1rcL3
 
+  redis:
+    image: redis:8.0-M03
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 1s
+      timeout: 3s
+      retries: 5
 
 # volumes:
 #   db_home:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250203-1852
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250204-1000
 
 services:
   superset:

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -16,7 +16,7 @@ ADMIN_PASSWORD="TODO"
 DATABASE_URI="postgresql://USR:PASS@WHATEVER.postgres.database.azure.com:5432/superset_metastore"
 
 # redis cache (shared instance for all projects, data partitioned by CACHE_KEY_PREFIX)
-REDIS_URL="rediss://:CONNECTIONSTR@superset-shared-cache.redis.cache.windows.net:6380"
+REDIS_URL="redis://redis:6379"
 CACHE_KEY_PREFIX="ss_PARTNERNAME_"
 
 # auth0 configurations

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -106,9 +106,9 @@ RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
 
 class CeleryConfig(object):
-    broker_url = (REDIS_URL,)
+    broker_url = REDIS_URL
     imports = ("superset.sql_lab",)
-    result_backend = (REDIS_URL,)
+    result_backend = REDIS_URL
     worker_prefetch_multiplier = 1
     task_acks_late = False
     beat_schedule = {

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -107,8 +107,10 @@ RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
 class CeleryConfig(object):
     broker_url = REDIS_URL
+    broker_transport_options = {"global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"}
     imports = ("superset.sql_lab",)
     result_backend = REDIS_URL
+    result_backend_transport_options = {"global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"}
     worker_prefetch_multiplier = 1
     task_acks_late = False
     beat_schedule = {

--- a/docker/requirements-addons.txt
+++ b/docker/requirements-addons.txt
@@ -2,3 +2,5 @@
 authlib>=1.3.1,<2
 # Install database drivers: https://superset.apache.org/docs/configuration/databases/#installing-database-drivers
 psycopg2-binary~=2.9.10
+# Install redis cache client: https://superset.apache.org/docs/configuration/cache/#dependencies
+redis~=5.2


### PR DESCRIPTION
To allow maximum flexibility of redis cache setup, this PR passes on the `REDIS_URL` env variable verbatim to superset (incl celery and Flask-Caching). That allows the administrator to config database numbers or SSL options as they wish. 

Closes ConservationMetrics/gc-forge#18
Closes #36

## What I changed

- No longer support redis different database numbers within a single deployment.  The only use case I'm aware of for these (quickly clearing an entire database) seems like a use case we'd do at the deployment level anyway.
- Different cache key prefixes for the 4 caches: this follows most recent guidance in the docs.
- Install redis client -  this seems to be a new-ish guidance, maybe from superset v4
- copy over task expiry option from the latest upstream code
- Usage is demonstrated in the `docker-compose.yml`

## How I know it works

* with a local redis server (no SSL), I passed `REDIS_URL="redis://redis:6379"` and confirmed celery polling the cache
* with a hosted redis server I passed `REDIS_URL="rediss://:CONNECTIONSTR@superset-shared-cache.redis.cache.windows.net:6380?ssl_cert_reqs=optional"` and confirmed I saw the appropriate keys get created in that cache.

Upon deployment, we may need to edit existing env variables to include that `?ssl...` suffix