### PR TITLE
Documentation updates for redis and use of SECRET_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,6 @@ Those dependencies are:
 
 We serve multiple clients and prefer to keep their deployments isolated from each other. Thus every client gets their own deployment: we create a separate VM (with its own web service, worker, initializer, etc), and PostgreSQL database for every client.
 
-At the moment, we share one Redis cache across all clients, with its keyspace partitioned by client (**superset-deployment**'s `CACHE_KEY_PREFIX` environment variable).
-
 ## A generic, deployable Docker image
 
 This repo roughly follows [how superset's own code base gets you started with Docker](https://github.com/apache/superset/tree/master/docker#production), but removes a lot of the distraction around local development, which is the focus of superset's documentation.

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -1,5 +1,8 @@
 COMPOSE_PROJECT_NAME=superset
 SECRET_KEY="TODO: openssl rand -base64 42 "
+# Once generated, this key should not be changed. It is used to encrypt passwords and connections in the database.
+# If you change this key, you will lose access to any data encrypted with the old key.
+# It is therefore essential to back up the key and keep it secure.
 
 # Optionally, set the application name and logo for the header. Default Superset
 # settings will be used if not set here.


### PR DESCRIPTION
This PR removes an outdated note about how we share one redis service, and adds information about how SECRET_KEYs are used in Superset and the importance of backing them up once deployed.