### PR TITLE
Bump v4.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # If you need to run locally, see the apache/superset Git repo instead.
 #
-FROM apache/superset:4.1.1
+FROM apache/superset:4.1.2
 
 COPY --chown=superset ./docker/docker-bootstrap.sh /app/docker/
 COPY --chown=superset ./docker/docker-init.sh /app/docker/

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ First you must commit to a specific release version of Superset, and
 
 - update that version in [`Dockerfile`](Dockerfile)
 - port any new changes to `superset_config.py` from that same tag upstream. This is manual and will require some diffing, something like:
-  - cd ~/dev/superset ; git checkout 4.1.1
+  - cd ~/dev/superset ; git checkout 4.1.2
   - diff ~/dev/superset/docker/pythonpath_dev/superset_config.py ~/dev/superset-deployment/docker/pythonpath/superset_config.py
 
 Now you can build the image, and might as well push it to the container registry too:
 
 ```bash
-SS_VERSION=4.1.1
+SS_VERSION=4.1.2
 BUILD=$(date +"%Y%m%d-%H%M")
 OUR_TAG="${SS_VERSION}_${BUILD}"
 docker build -t guardiancr.azurecr.io/superset-docker:${OUR_TAG} .

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -72,7 +72,7 @@ caproverOneClickApp:
   variables:
     - id: '$$cap_superset_docker_image'
       label: Superset Docker Image
-      defaultValue: 'guardiancr.azurecr.io/superset-docker:4.1.1_20250203-1852'
+      defaultValue: 'guardiancr.azurecr.io/superset-docker:4.1.2_20250519-1315'
       description: Check out the container registry for valid tags
     - id: '$$cap_superset_admin_email'
       label: Email for Superset admin user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.1_20250204-1032
+x-superset-image: &superset-image guardiancr.azurecr.io/superset-docker:4.1.2_20250519-1315
 
 services:
   superset:


### PR DESCRIPTION
# Goal

Fixes:
> Improper Authorization vulnerability in Apache Superset allows ownership takeover of dashboards, charts or datasets by authenticated users with read permissions. This issue affects Apache Superset: through 4.1.1. Users are recommended to upgrade to version 4.1.2 or above, which fixes the issue.

# Status
New image is built

but not yet deployed