### PR TITLE
Use "Alpha" as default role, and remove setting of USER_ROLE_PERMISSIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ The starting Role of the user once approved is determined by a `USER_ROLE` envir
 
 Currently, we default to "Alpha" because it grants broad dashboard/chart access without the ability to view or edit database credentials or create new datasets, thus striking a balance between usability and security. "Admin privileges" are reserved for a small group, such as the very first Superset user. "Gamma" can be appropriate for strictly read-only users needing per-asset permissions. 
 
+For an exhaustive list of roles and permissions, see [STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md). Here's a truncated summary:
+
+| Role   | Access Level Summary |
+|--------|----------------------|
+| Admin  | Full access. Can manage users, roles, all data sources, dashboards, and credentials. Can grant/revoke access. |
+| Alpha  | Can access all data sources and dashboards, create/modify their own dashboards/slices. Cannot manage users or view credentials. |
+| Gamma  | Read-only by default. Can only see charts/dashboards from explicitly granted data sources. Cannot edit or add data sources. |
+
 ## Optional environmental variables
 
 To allow for flexible customization, we have provided several optional environmental variables (commented out in `.env.sample`):

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ To allow for flexible customization, we have provided several optional environme
 
 * `APP_NAME`: if you want the page title for the dashboard to be something different than "Superset"
 * `APP_ICON`: to change the Superset logo shown on the top left of the window.
-* `USER_ROLE_PERMISSIONS`: if you want to assign additional permissions to the Starting role of a user once approved as defined in `USER_ROLE`. Note that setting these means that any changes made to the permissions for that user role (e.g. in the Superset UI) will be overwritten upon deployment of the application.
 * `FRAME_ANCESTORS`: to provide a comma separated list of permissible frame ancestors for your CSP.
 * `MAPBOX_API_KEY`
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,13 @@ After it's done, you _may_ remove the `superset-init` service.
 
 We are using auth0 for authentication. For auth0 to work, you will need to provide the relevant environmental variables shown in `.env`, and configure your auth0 tentant according to your needs. By default, Superset account registration is enabled. Users may authenticate using auth0 based on their username, which should match their auth0 email address. Upon initial registration, the user will first see a message that their request to sign in was denied. That is because the user's account needs to be approved by an auth0 admin; once that's been done, they will be able to log in to Superset without issue.
 
+Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using environmental variables to create an admin user whose username should match your auth0 email account.
+
+## User roles
+
 The starting Role of the user once approved is determined by a `USER_ROLE` environmental variable. Please see [this guide on Superset roles](https://superset.apache.org/docs/security/) to set the appropriate starting Role for your deployment. The fallback value is "Alpha" if the var is not set.
 
-Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using environmental variables to create an admin user whose username should match your auth0 email account.
+Currently, we default to "Alpha" because it grants broad dashboard/chart access without the ability to view or edit database credentials or create new datasets, thus striking a balance between usability and security. "Admin privileges" are reserved for a small group, such as the very first Superset user. "Gamma" can be appropriate for strictly read-only users needing per-asset permissions. 
 
 ## Optional environmental variables
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ After it's done, you _may_ remove the `superset-init` service.
 
 We are using auth0 for authentication. For auth0 to work, you will need to provide the relevant environmental variables shown in `.env`, and configure your auth0 tentant according to your needs. By default, Superset account registration is enabled. Users may authenticate using auth0 based on their username, which should match their auth0 email address. Upon initial registration, the user will first see a message that their request to sign in was denied. That is because the user's account needs to be approved by an auth0 admin; once that's been done, they will be able to log in to Superset without issue.
 
-The starting Role of the user once approved is determined by a `USER_ROLE` environmental variable. Please see [this guide on Superset roles](https://superset.apache.org/docs/security/) to set the appropriate starting Role for your deployment. The fallback value is "Gamma" if the var is not set.
+The starting Role of the user once approved is determined by a `USER_ROLE` environmental variable. Please see [this guide on Superset roles](https://superset.apache.org/docs/security/) to set the appropriate starting Role for your deployment. The fallback value is "Alpha" if the var is not set.
 
 Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using environmental variables to create an admin user whose username should match your auth0 email account.
 

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -19,7 +19,7 @@ services:
       MAPBOX_API_KEY: $$cap_mapbox_api_key
       APP_ICON: $$cap_app_icon
       APP_NAME: $$cap_app_title
-      USER_ROLE: Gamma
+      USER_ROLE: Alpha
       USER_ROLE_PERMISSIONS: "(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
       LANGUAGES: "{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
       FRAME_ANCESTORS: "https://*.guardianconnector.net"

--- a/caprover/one-click-apps/superset-only.yml
+++ b/caprover/one-click-apps/superset-only.yml
@@ -20,7 +20,6 @@ services:
       APP_ICON: $$cap_app_icon
       APP_NAME: $$cap_app_title
       USER_ROLE: Alpha
-      USER_ROLE_PERMISSIONS: "(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
       LANGUAGES: "{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
       FRAME_ANCESTORS: "https://*.guardianconnector.net"
     caproverExtra:

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -27,8 +27,9 @@ AUTH0_DOMAIN="xxx.us.auth0.com"
 AUTH0_CLIENTID="YOUR AUTH0 CLIENT ID HERE"
 AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
 
-# Superset user registration config
-USER_ROLE="Gamma"
+# Superset default user role. See standard roles for reference:
+# https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md
+USER_ROLE="Alpha"
 
 # Optional, comma-separated list of "(),(),()..." of valid permissions for your user role.
 # Each tuple is a 2-tuple: (permission_name, view_name).

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -31,19 +31,6 @@ AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
 # https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md
 USER_ROLE="Alpha"
 
-# Optional, comma-separated list of "(),(),()..." of valid permissions for your user role.
-# Each tuple is a 2-tuple: (permission_name, view_name).
-# USER_ROLE_PERMISSIONS="(can_read,Chart),(all_datasource_access,all_datasource_access),(all_database_access,all_database_access),(all_query_access,all_query_access)"
-# 
-# For more about permissions, refer to the Superset documentation:
-# https://superset.apache.org/docs/security/#customizing-permissions
-# https://incubator-superset.readthedocs.io/en/latest/security.html
-#
-# Please note that global permissions that don't apply to a single view 
-# such as 'all_datasource_access' need to still be in a 2-tuple format
-# with the user role permission repeated instead of the view name
-# e.g. (all_datasource_access,all_datasource_access)
-
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
 MAPBOX_API_KEY="YOUR MAP KEY HERE"
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -213,7 +213,7 @@ class CustomAuthOAuthView(AuthOAuthView):
         return response
 
 
-USER_ROLE = get_env_variable("USER_ROLE", "Gamma")
+USER_ROLE = get_env_variable("USER_ROLE", "Alpha")
 USER_ROLE_PERMISSIONS = get_env_variable("USER_ROLE_PERMISSIONS", "")
 
 # Parse USER_ROLE_PERMISSIONS into a list of tuples

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -26,17 +26,15 @@ import os
 from datetime import timedelta
 from typing import Optional
 
-from flask_appbuilder.security.manager import AUTH_OAUTH
-from flask_appbuilder.security.views import AuthOAuthView
-from flask_appbuilder import expose
-from flask import flash, get_flashed_messages
-from flask_babel import get_locale
-from werkzeug.wrappers import Response as WerkzeugResponse
-
-from superset.security import SupersetSecurityManager
-
 from cachelib.file import FileSystemCache
 from celery.schedules import crontab
+from flask import flash, get_flashed_messages
+from flask_appbuilder import expose
+from flask_appbuilder.security.manager import AUTH_OAUTH
+from flask_appbuilder.security.views import AuthOAuthView
+from flask_babel import get_locale
+from superset.security import SupersetSecurityManager
+from werkzeug.wrappers import Response as WerkzeugResponse
 
 logger = logging.getLogger()
 
@@ -49,7 +47,9 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
         if default is not None:
             return default
         else:
-            error_msg = "The environment variable {} was missing, abort...".format(var_name)
+            error_msg = "The environment variable {} was missing, abort...".format(
+                var_name
+            )
             raise EnvironmentError(error_msg)
 
 
@@ -110,7 +110,9 @@ class CeleryConfig(object):
     broker_transport_options = {"global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"}
     imports = ("superset.sql_lab",)
     result_backend = REDIS_URL
-    result_backend_transport_options = {"global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"}
+    result_backend_transport_options = {
+        "global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"
+    }
     worker_prefetch_multiplier = 1
     task_acks_late = False
     beat_schedule = {
@@ -213,46 +215,10 @@ class CustomAuthOAuthView(AuthOAuthView):
         return response
 
 
-USER_ROLE = get_env_variable("USER_ROLE", "Alpha")
-USER_ROLE_PERMISSIONS = get_env_variable("USER_ROLE_PERMISSIONS", "")
-
-# Parse USER_ROLE_PERMISSIONS into a list of tuples
-if USER_ROLE_PERMISSIONS:
-    user_role_pvms = [
-        tuple(permission.strip("()").split(","))
-        for permission in USER_ROLE_PERMISSIONS.split("),(")
-    ]
-else:
-    user_role_pvms = []
-
-
 # https://superset.apache.org/docs/installation/configuring-superset/#custom-oauth2-configuration
 # We need to override the default security manager to use Auth0
 class CustomSecurityManager(SupersetSecurityManager):
     authoauthview = CustomAuthOAuthView
-
-    # https://github.com/apache/superset/issues/8864#issuecomment-1716449362
-    def __init__(self, appbuilder):
-        super().__init__(appbuilder)
-
-        if user_role_pvms:
-            # Find the user role
-            user_role = self.find_role(USER_ROLE)
-
-            logger.info(f"User role permissions to add to {user_role}: {user_role_pvms}")
-
-            if user_role:
-                for permission in user_role_pvms:
-                    if len(permission) == 2:
-                        action, model = permission
-                        pvm = self.find_permission_view_menu(action, model)
-                        if pvm is None:
-                            logger.error(f"Permission {permission} not found for role {user_role}")
-                        else:
-                            logger.info(f"Adding permission {pvm} to role {user_role}")
-                            self.add_permission_role(user_role, pvm)
-                    else:
-                        logger.warning("Permission is not a 2-tuple. Skipping...")
 
     def oauth_user_info(self, provider, response=None):
         logging.debug("Oauth2 provider: {0}.".format(provider))
@@ -284,6 +250,8 @@ class CustomSecurityManager(SupersetSecurityManager):
             }
 
 
+USER_ROLE = get_env_variable("USER_ROLE", "Alpha")
+
 # Uses standard Superset authentication and authorization by default.
 # To use Auth0 instead, set the three AUTH0_* variables:
 AUTH0_DOMAIN = get_env_variable("AUTH0_DOMAIN", "")
@@ -310,9 +278,13 @@ if AUTH0_DOMAIN:
                     "scope": "openid profile email",
                 },
                 "access_token_method": "POST",
-                "access_token_params": {"client_id": get_env_variable("AUTH0_CLIENTID")},
+                "access_token_params": {
+                    "client_id": get_env_variable("AUTH0_CLIENTID")
+                },
                 "jwks_uri": f"https://{AUTH0_DOMAIN}/.well-known/jwks.json",
-                "access_token_headers": {"Authorization": "Basic Base64EncodedClientIdAndSecret"},
+                "access_token_headers": {
+                    "Authorization": "Basic Base64EncodedClientIdAndSecret"
+                },
                 "api_base_url": f"https://{AUTH0_DOMAIN}/oauth/",
                 "access_token_url": f"https://{AUTH0_DOMAIN}/oauth/token",
                 "authorize_url": f"https://{AUTH0_DOMAIN}/authorize",
@@ -349,6 +321,8 @@ try:
     import superset_config_docker
     from superset_config_docker import *  # noqa
 
-    logger.info(f"Loaded your Docker configuration at [{superset_config_docker.__file__}]")
+    logger.info(
+        f"Loaded your Docker configuration at [{superset_config_docker.__file__}]"
+    )
 except ImportError:
     logger.info("Using default Docker config...")


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/superset-deployment/issues/48 and https://github.com/ConservationMetrics/gc-programs/issues/67. This PR addresses the original user requirement in a much better way: by assigning a built-in role that meets the needs of our users, and removing the problematic code entirely.

As it turns out, Superset has a default permission "Alpha" that includes all of the permissions that we have been trying to bend over backwards to assign to "Gamma"!

Per https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md, Alpha already has `all_datasource_access` and `all_database_access`. (I don't think we actually need our non-admin users to have `all_query_access`).

I've updated all Gamma users to Alpha across our deployments and confirmed they can access everything they should (and nothing they shouldn't).

This means that **we don't need to set `USER_ROLE_PERMISSIONS` at all anymore**, so this PR removes it interest of needing to maintain as little code as possible.

The other change made by his PR is setting the default / fallback USER_ROLE to Alpha.


