### PR TITLE
Set username as ADMIN_EMAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,9 @@ After it's done, you _may_ remove the `superset-init` service.
 
 ## Authentication
 
-We are using auth0 for authentication. For auth0 to work, you will need to provide the relevant environmental variables shown in `.env`, and configure your auth0 tentant according to your needs. By default, Superset account registration is enabled. Users may authenticate using auth0 based on their username, which should match their auth0 email address. Upon initial registration, the user will first see a message that their request to sign in was denied. That is because the user's account needs to be approved by an auth0 admin; once that's been done, they will be able to log in to Superset without issue.
+We are using auth0 for authentication. For auth0 to work, you will need to provide the relevant environmental variables shown in `.env`, and configure your auth0 tenant according to your needs. By default, Superset account registration is enabled. Users may authenticate using auth0 based on their username, which should match their auth0 email address. Upon initial registration, the user will first see a message that their request to sign in was denied. That is because the user's account needs to be approved by an auth0 admin; once that's been done, they will be able to log in to Superset without issue.
 
-Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using environmental variables to create an admin user whose username should match your auth0 email account.
+Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/latest/security.html#authentication-methods) for authentication, which can only handle one type of authentication method and this means the standard authentication protocols are not accessible. Hence, for initial Superset db setup, we are using the environmental variable `ADMIN_EMAIL` to create an admin user whose username (as an email address) should match your auth0 email account. (If you are using auth0, `ADMIN_PASSWORD` is not used.)
 
 ## User roles
 

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -12,7 +12,6 @@ SECRET_KEY="TODO: openssl rand -base64 42 "
 # Admin user is created during initialization. Authentication will be handled by Auth0
 # using the username, which should match the email address of the auth0 user.
 ADMIN_EMAIL=admin@yourdomain.net
-ADMIN_USERNAME=admin@yourdomain.net
 ADMIN_PASSWORD="TODO"
 
 # database configurations

--- a/docker/docker-init.sh
+++ b/docker/docker-init.sh
@@ -53,7 +53,7 @@ echo_step "1" "Complete" "Applying DB migrations"
 # Create an admin user
 echo_step "2" "Starting" "Setting up admin user"
 superset fab create-admin \
-              --username admin \
+              --username $ADMIN_EMAIL \
               --firstname Warehouse \
               --lastname Admin \
               --email $ADMIN_EMAIL \


### PR DESCRIPTION
Addressing https://github.com/ConservationMetrics/gc-deploy/issues/23#issuecomment-3177068696.

It seems that given the documentation in this repository, we are already expecting an admin username to be accessed via auth0 (once set by ADMIN_EMAIL) :open_mouth: 

I'd love to test this but I was having an issue running Docker compose locally and the logs were sort of nebulous, and I just don't have the time to debug that right now. But at least pushing this change which we can deploy on CapRover.

Also, removed ADMIN_USERNAME from `.env.example` as it was apparently vestigial.