### PR TITLE
Turn off Scarf tracking pixel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN pip install --no-cache-dir -r /app/docker/requirements-addons.txt
 COPY --chown=superset ./docker/pythonpath/superset_config.py /app/pythonpath/
 ENV PYTHONPATH="${PYTHONPATH}:/app/pythonpath/"
 
+ENV SCARF_ANALYTICS=false
 ENV FLASK_ENV=production
 ENV SUPERSET_ENV=production
 


### PR DESCRIPTION
Example of a request that this would disable:
GET https://apachesuperset.gateway.scarf.sh/pixel/0d3461e1-abb1-4691-a0aa-5ed50de66af0/4.1.2//null

More about scarf: https://about.scarf.sh/