### PR TITLE
Use theme overrides in `superset_config.py` to set logo and app name

### DIFF
--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -53,9 +53,25 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
             raise EnvironmentError(error_msg)
 
 
-APP_NAME = get_env_variable("APP_NAME", "Superset")
+# Enable UI-based theme administration for admins
+# https://superset.apache.org/admin-docs/configuration/theming/
+ENABLE_UI_THEME_ADMINISTRATION = True
 
+APP_NAME = get_env_variable("APP_NAME", "Superset")
+BRAND_LOGO_URL = get_env_variable(
+    "BRAND_LOGO_URL", "/static/assets/images/superset-logo-horiz.png"
+)
+
+# For backward compatibility
 APP_ICON = get_env_variable("APP_ICON", "/static/assets/images/superset-logo-horiz.png")
+
+THEME_DEFAULT = {
+    "token": {"brandAppName": APP_NAME, "brandLogoUrl": BRAND_LOGO_URL or APP_ICON}
+}
+
+THEME_DARK = {
+    "token": {"brandAppName": APP_NAME, "brandLogoUrl": BRAND_LOGO_URL or APP_ICON}
+}
 
 SECRET_KEY = get_env_variable("SECRET_KEY")
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -53,21 +53,16 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
             raise EnvironmentError(error_msg)
 
 
-# Enable UI-based theme administration for admins
-# https://superset.apache.org/admin-docs/configuration/theming/
-ENABLE_UI_THEME_ADMINISTRATION = True
-
 APP_NAME = get_env_variable("APP_NAME", "Superset")
 LOGO_URL = get_env_variable("LOGO_URL")
 
 # For backward compatibility
 APP_ICON = get_env_variable("APP_ICON")
 
+# https://superset.apache.org/admin-docs/configuration/theming/
 THEME_DEFAULT = {
     "token": {"brandAppName": APP_NAME, "brandLogoUrl": LOGO_URL or APP_ICON}
 }
-
-THEME_DARK = {"token": {"brandAppName": APP_NAME, "brandLogoUrl": LOGO_URL or APP_ICON}}
 
 SECRET_KEY = get_env_variable("SECRET_KEY")
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -58,10 +58,10 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
 ENABLE_UI_THEME_ADMINISTRATION = True
 
 APP_NAME = get_env_variable("APP_NAME", "Superset")
-LOGO_URL = get_env_variable("LOGO_URL", "/static/assets/images/superset-logo-horiz.png")
+LOGO_URL = get_env_variable("LOGO_URL")
 
 # For backward compatibility
-APP_ICON = get_env_variable("APP_ICON", "/static/assets/images/superset-logo-horiz.png")
+APP_ICON = get_env_variable("APP_ICON")
 
 THEME_DEFAULT = {
     "token": {"brandAppName": APP_NAME, "brandLogoUrl": LOGO_URL or APP_ICON}

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -58,20 +58,16 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
 ENABLE_UI_THEME_ADMINISTRATION = True
 
 APP_NAME = get_env_variable("APP_NAME", "Superset")
-BRAND_LOGO_URL = get_env_variable(
-    "BRAND_LOGO_URL", "/static/assets/images/superset-logo-horiz.png"
-)
+LOGO_URL = get_env_variable("LOGO_URL", "/static/assets/images/superset-logo-horiz.png")
 
 # For backward compatibility
 APP_ICON = get_env_variable("APP_ICON", "/static/assets/images/superset-logo-horiz.png")
 
 THEME_DEFAULT = {
-    "token": {"brandAppName": APP_NAME, "brandLogoUrl": BRAND_LOGO_URL or APP_ICON}
+    "token": {"brandAppName": APP_NAME, "brandLogoUrl": LOGO_URL or APP_ICON}
 }
 
-THEME_DARK = {
-    "token": {"brandAppName": APP_NAME, "brandLogoUrl": BRAND_LOGO_URL or APP_ICON}
-}
+THEME_DARK = {"token": {"brandAppName": APP_NAME, "brandLogoUrl": LOGO_URL or APP_ICON}}
 
 SECRET_KEY = get_env_variable("SECRET_KEY")
 


### PR DESCRIPTION
Closes https://github.com/ConservationMetrics/superset-deployment/issues/60.

Note that APP_NAME does not set the window title in 6.0.0, because that was a bug discovered [here](https://github.com/apache/superset/issues/34865#issuecomment-3546392815) and a bugfix was filed [here](https://github.com/apache/superset/pull/37370). When we upgrade to 6.1,0, it should work.