### PR TITLE
Bump Apache Superset to 6.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 # If you need to run locally, see the apache/superset Git repo instead.
 #
-FROM apache/superset:6.0.0
+FROM apache/superset:6.1.0
 
 COPY --chown=superset --chmod=0755 ./docker/docker-bootstrap.sh /app/docker/
 COPY --chown=superset --chmod=0755 ./docker/docker-init.sh /app/docker/
@@ -13,7 +13,7 @@ COPY --chown=superset --chmod=0755 ./docker/docker-init.sh /app/docker/
 
 # Specify your own python libraries in requirements-addons.txt
 # Install into venv as root using uv (see docs):
-# https://superset.apache.org/user-docs/6.0.0/installation/docker-builds/#building-your-own-production-docker-image 
+# https://superset.apache.org/user-docs/6.1.0/installation/docker-builds/#building-your-own-production-docker-image
 COPY --chown=superset ./docker/requirements-addons.txt /app/docker/
 USER root
 RUN . /app/.venv/bin/activate \

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ First you must commit to a specific release version of Superset, and
 
 - update that version in [`Dockerfile`](Dockerfile)
 - port any new changes to `superset_config.py` from that same tag upstream. This is manual and will require some diffing, something like:
-  - cd ~/dev/superset ; git checkout 6.0.0
+  - cd ~/dev/superset ; git checkout 6.1.0
   - diff ~/dev/superset/docker/pythonpath_dev/superset_config.py ~/dev/superset-deployment/docker/pythonpath/superset_config.py
 
 Now you can build the image, and might as well push it to the container registry too:
 
 ```bash
-SS_VERSION=6.0.0
+SS_VERSION=6.1.0
 BUILD=$(date +"%Y%m%d-%H%M")
 OUR_TAG="${SS_VERSION}_${BUILD}"
 REGISTRY=your-registry-name


### PR DESCRIPTION
## Goal

Build the CMI Superset deployment image from Apache Superset 6.1.0.

## What changed

Updated the Docker base image from Superset 6.0.0 to 6.1.0 and aligned the related documentation references.

## Verification

Confirmed no 6.0.0 references remain and the diff passes whitespace validation. The PR workflow will build the 6.1.0 test image.

## Not included

