### PR TITLE
Map Superset roles to our auth0 RBAC roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,14 @@ Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/late
 
 ## User roles
 
+For an exhaustive list of roles and permissions, see [STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md). Here's a truncated summary:
+
+| Role   | Access Level Summary |
+|--------|----------------------|
+| Admin  | Full access. Can manage users, roles, all data sources, dashboards, and credentials. Can grant/revoke access. |
+| Alpha  | Can access all data sources and dashboards, create/modify their own dashboards/slices. Cannot manage users or view credentials. |
+| Gamma  | Read-only by default. Can only see charts/dashboards from explicitly granted data sources. Cannot edit or add data sources. |
+
 Superset roles are synced from Auth0 on every login via `AUTH_ROLES_MAPPING`:
 
 | Auth0 role | Superset role |
@@ -133,15 +141,22 @@ Superset roles are synced from Auth0 on every login via `AUTH_ROLES_MAPPING`:
 | Guest      | Gamma         |
 | SignedIn   | Public        |
 
-Users with no Auth0 role fall back to Public. Assign Auth0 roles in the Auth0 dashboard (or via an Action that sets `urn:gc:roles`).
+Users with no Auth0 role fall back to Public. Assign Auth0 roles in the Auth0 dashboard.
 
-For an exhaustive list of roles and permissions, see [STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md). Here's a truncated summary:
+### Auth0 Post-Login Action
 
-| Role   | Access Level Summary |
-|--------|----------------------|
-| Admin  | Full access. Can manage users, roles, all data sources, dashboards, and credentials. Can grant/revoke access. |
-| Alpha  | Can access all data sources and dashboards, create/modify their own dashboards/slices. Cannot manage users or view credentials. |
-| Gamma  | Read-only by default. Can only see charts/dashboards from explicitly granted data sources. Cannot edit or add data sources. |
+Superset reads roles from the `urn.gc.roles` claim on `/userinfo` (Auth0 rewrites `urn:gc:roles` → `urn.gc.roles`). Add this **Login / Post Login** Action in Auth0 (Actions → Library → Build Custom), then attach it to the Login flow:
+
+```javascript
+/**
+ * Handler that will be called during the execution of a PostLogin flow.
+ */
+exports.onExecutePostLogin = async (event, api) => {
+  if (event.authorization) {
+    api.idToken.setCustomClaim("urn:gc:roles", event.authorization.roles);
+  }
+};
+```
 
 ## Optional environmental variables
 

--- a/README.md
+++ b/README.md
@@ -124,9 +124,16 @@ Superset uses [Flask-AppBuilder](https://flask-appbuilder.readthedocs.io/en/late
 
 ## User roles
 
-The starting Role of the user once approved is determined by a `USER_ROLE` environmental variable. Please see [this guide on Superset roles](https://superset.apache.org/docs/security/) to set the appropriate starting Role for your deployment. The fallback value is "Alpha" if the var is not set.
+Superset roles are synced from Auth0 on every login via `AUTH_ROLES_MAPPING`:
 
-Currently, we default to "Alpha" because it grants broad dashboard/chart access without the ability to view or edit database credentials or create new datasets, thus striking a balance between usability and security. "Admin privileges" are reserved for a small group, such as the very first Superset user. "Gamma" can be appropriate for strictly read-only users needing per-asset permissions. 
+| Auth0 role | Superset role |
+|------------|---------------|
+| Admin      | Admin         |
+| Member     | Alpha         |
+| Guest      | Gamma         |
+| SignedIn   | Public        |
+
+Users with no Auth0 role fall back to Public. Assign Auth0 roles in the Auth0 dashboard (or via an Action that sets `urn:gc:roles`).
 
 For an exhaustive list of roles and permissions, see [STANDARD_ROLES.md](https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md). Here's a truncated summary:
 

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -24,14 +24,6 @@ CACHE_KEY_PREFIX="ss_PARTNERNAME_"
 AUTH0_DOMAIN="xxx.us.auth0.com"
 AUTH0_CLIENTID="YOUR AUTH0 CLIENT ID HERE"
 AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
-# Roles are fetched via Management API (GET /api/v2/users/{id}/roles) using
-# client_credentials. Authorize this app for the Management API with
-# read:users, read:roles, and read:role_members (same pattern as gc-explorer).
-
-# Superset fallback role when Auth0 returns no mappable roles. See:
-# https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md
-# Mapped Auth0 roles (Admin/Member/Guest/SignedIn) override this at login.
-USER_ROLE="Alpha"
 
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"
 MAPBOX_API_KEY="YOUR MAP KEY HERE"

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -24,11 +24,11 @@ CACHE_KEY_PREFIX="ss_PARTNERNAME_"
 AUTH0_DOMAIN="xxx.us.auth0.com"
 AUTH0_CLIENTID="YOUR AUTH0 CLIENT ID HERE"
 AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
-# Optional: namespaced Auth0 roles claim (e.g. "https://your-app.example.com/roles").
-# Leave empty to auto-detect "roles" or any claim ending in "/roles".
-# AUTH0_ROLES_CLAIM="https://your-app.example.com/roles"
+# Roles are fetched via Management API (GET /api/v2/users/{id}/roles) using
+# client_credentials. Authorize this app for the Management API with
+# read:users, read:roles, and read:role_members (same pattern as gc-explorer).
 
-# Superset fallback role when Auth0 sends no mappable roles. See:
+# Superset fallback role when Auth0 returns no mappable roles. See:
 # https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md
 # Mapped Auth0 roles (Admin/Member/Guest/SignedIn) override this at login.
 USER_ROLE="Alpha"

--- a/docker/.env.sample
+++ b/docker/.env.sample
@@ -24,9 +24,13 @@ CACHE_KEY_PREFIX="ss_PARTNERNAME_"
 AUTH0_DOMAIN="xxx.us.auth0.com"
 AUTH0_CLIENTID="YOUR AUTH0 CLIENT ID HERE"
 AUTH0_CLIENT_SECRET="YOUR AUTH0 CLIENT SECRET HERE"
+# Optional: namespaced Auth0 roles claim (e.g. "https://your-app.example.com/roles").
+# Leave empty to auto-detect "roles" or any claim ending in "/roles".
+# AUTH0_ROLES_CLAIM="https://your-app.example.com/roles"
 
-# Superset default user role. See standard roles for reference:
+# Superset fallback role when Auth0 sends no mappable roles. See:
 # https://github.com/apache/superset/blob/master/RESOURCES/STANDARD_ROLES.md
+# Mapped Auth0 roles (Admin/Member/Guest/SignedIn) override this at login.
 USER_ROLE="Alpha"
 
 LANGUAGES="{\"en\": {\"flag\": \"us\", \"name\": \"English\"}, \"pt_BR\": {\"flag\": \"br\", \"name\": \"Português\"}, \"es\": {\"flag\": \"mx\", \"name\": \"Español\"}, \"fr\": {\"flag\": \"fr\", \"name\": \"Français\"}, \"nl\": {\"flag\": \"sr\", \"name\": \"Nederlands\"}}"

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -229,7 +229,7 @@ class CustomSecurityManager(SupersetSecurityManager):
                 return
             me = res.json()
             # Uncomment the following line to inspect the returned user data
-            # logger.debug(" user_data: %s", me)
+            logger.debug(" user_data: %s", me)
 
             # Auth0 returns a full name, but Superset expects first/last name
             # We'll split the full name into two parts, but note that this is

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -232,22 +232,23 @@ class CustomSecurityManager(SupersetSecurityManager):
                 return
             me = res.json()
 
-            res = (
-                self.appbuilder.sm.oauth_remotes[provider]
-                .get(f"https://{AUTH0_DOMAIN}/api/v2/users/{me['sub']}/roles")
-                .json()
+            # Uncomment the following line to inspect the returned user data
+            logger.debug(" user_data: %s", me)
+
+            res = self.appbuilder.sm.oauth_remotes[provider].get(
+                f"https://{AUTH0_DOMAIN}/api/v2/users/{me['sub']}/roles"
             )
             if res.raw.status != 200:
-                logger.error("Failed to obtain user info.")
+                logger.error(
+                    "Failed to obtain user roles: status=%s body=%s",
+                    res.raw.status,
+                    res.text,
+                )
                 return
             roles = res.json()
             logger.debug(" roles: %s", roles)
 
             role_keys = [role["name"] for role in roles]
-            # TODO: Add logic to fetch roles from auth0 https://auth0.com/docs/api/management/v2/users/get-user-roles
-
-            # Uncomment the following line to inspect the returned user data
-            logger.debug(" user_data: %s", me)
 
             return {
                 "username": me["email"],

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -240,7 +240,7 @@ class CustomSecurityManager(SupersetSecurityManager):
                 "email": me["email"],
                 "first_name": me["given_name"],
                 "last_name": me["family_name"],
-                "role_keys": me.get("urn:gc:roles", []),
+                "role_keys": me.get("urn.gc.roles", []),
             }
 
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -24,7 +24,6 @@ import json
 import logging
 import os
 from datetime import timedelta
-from typing import Optional
 
 from cachelib.file import FileSystemCache
 from celery.schedules import crontab
@@ -42,7 +41,7 @@ logger = logging.getLogger()
 # LOG_LEVEL = logging.DEBUG
 
 
-def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
+def get_env_variable(var_name: str, default: str | None = None) -> str:
     """Get the environment variable or raise exception."""
     try:
         return os.environ[var_name]
@@ -50,10 +49,8 @@ def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
         if default is not None:
             return default
         else:
-            error_msg = "The environment variable {} was missing, abort...".format(
-                var_name
-            )
-            raise EnvironmentError(error_msg)
+            error_msg = f"The environment variable {var_name} was missing, abort..."
+            raise OSError(error_msg)
 
 
 APP_NAME = get_env_variable("APP_NAME", "Superset")
@@ -106,7 +103,7 @@ CELERY_BEAT_SCHEDULER_EXPIRES = timedelta(weeks=1)
 RESULTS_BACKEND = FileSystemCache("/app/superset_home/sqllab")
 
 
-class CeleryConfig(object):
+class CeleryConfig:
     broker_url = REDIS_URL
     broker_transport_options = {"global_keyprefix": f"{CACHE_KEY_PREFIX}celery_"}
     imports = ("superset.sql_lab",)
@@ -222,7 +219,7 @@ class CustomSecurityManager(SupersetSecurityManager):
     authoauthview = CustomAuthOAuthView
 
     def oauth_user_info(self, provider, response=None):
-        logger.debug("Oauth2 provider: {0}.".format(provider))
+        logger.debug(f"Oauth2 provider: {provider}.")
         if provider == "auth0":
             res = self.appbuilder.sm.oauth_remotes[provider].get(
                 f"https://{AUTH0_DOMAIN}/userinfo"
@@ -253,6 +250,7 @@ class CustomSecurityManager(SupersetSecurityManager):
 
 
 # https://superset.apache.org/user-docs/6.0.0/configuration/configuring-superset/#mapping-oauth-groups-to-superset-roles
+# https://github.com/ConservationMetrics/gc-deploy/tree/main/auth0#role-setup
 AUTH_ROLES_SYNC_AT_LOGIN = True
 AUTH_ROLES_MAPPING = {
     "Admin": ["Admin"],
@@ -328,7 +326,7 @@ HTML_SANITIZATION_SCHEMA_EXTENSIONS = {
 #
 try:
     import superset_config_docker
-    from superset_config_docker import *  # noqa
+    from superset_config_docker import *
 
     logger.info(
         f"Loaded your Docker configuration at [{superset_config_docker.__file__}]"

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -38,6 +38,8 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 
 logger = logging.getLogger()
 
+LOG_LEVEL = logging.DEBUG
+
 
 def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
     """Get the environment variable or raise exception."""
@@ -219,7 +221,7 @@ class CustomSecurityManager(SupersetSecurityManager):
     authoauthview = CustomAuthOAuthView
 
     def oauth_user_info(self, provider, response=None):
-        logging.debug("Oauth2 provider: {0}.".format(provider))
+        logger.debug("Oauth2 provider: {0}.".format(provider))
         if provider == "auth0":
             res = self.appbuilder.sm.oauth_remotes[provider].get(
                 f"https://{AUTH0_DOMAIN}/userinfo"
@@ -229,7 +231,7 @@ class CustomSecurityManager(SupersetSecurityManager):
                 return
             me = res.json()
             # Uncomment the following line to inspect the returned user data
-            logger.info(" user_data: %s", me)
+            logger.debug(" user_data: %s", me)
 
             # Auth0 returns a full name, but Superset expects first/last name
             # We'll split the full name into two parts, but note that this is
@@ -249,11 +251,13 @@ class CustomSecurityManager(SupersetSecurityManager):
 
 
 # https://superset.apache.org/user-docs/6.0.0/configuration/configuring-superset/#mapping-oauth-groups-to-superset-roles
+AUTH_ROLES_SYNC_AT_LOGIN = True
+
 AUTH_ROLES_MAPPING = {
     "Admin": ["Admin"],
     "Member": ["Alpha"],
     "Guest": ["Gamma"],
-    "SignedIn": ["Gamma"],
+    "SignedIn": ["Public"],
 }
 
 # Fallback user role if no mapping is found.

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -248,6 +248,15 @@ class CustomSecurityManager(SupersetSecurityManager):
             }
 
 
+# https://superset.apache.org/user-docs/6.0.0/configuration/configuring-superset/#mapping-oauth-groups-to-superset-roles
+AUTH_ROLES_MAPPING = {
+    "Admin": ["Admin"],
+    "Member": ["Alpha"],
+    "Guest": ["Gamma"],
+    "SignedIn": ["Gamma"],
+}
+
+# Fallback user role if no mapping is found.
 USER_ROLE = get_env_variable("USER_ROLE", "Alpha")
 
 # Uses standard Superset authentication and authorization by default.

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -235,27 +235,12 @@ class CustomSecurityManager(SupersetSecurityManager):
             # Uncomment the following line to inspect the returned user data
             logger.debug(" user_data: %s", me)
 
-            res = self.appbuilder.sm.oauth_remotes[provider].get(
-                f"https://{AUTH0_DOMAIN}/api/v2/users/{me['sub']}/roles"
-            )
-            if res.raw.status != 200:
-                logger.error(
-                    "Failed to obtain user roles: status=%s body=%s",
-                    res.raw.status,
-                    res.text,
-                )
-                return
-            roles = res.json()
-            logger.debug(" roles: %s", roles)
-
-            role_keys = [role["name"] for role in roles]
-
             return {
                 "username": me["email"],
                 "email": me["email"],
                 "first_name": me["given_name"],
                 "last_name": me["family_name"],
-                "role_keys": role_keys,
+                "role_keys": me.get("urn:gc:roles", []),
             }
 
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -39,7 +39,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 logger = logging.getLogger()
 
 # Uncomment to enable debug logging
-LOG_LEVEL = logging.DEBUG
+# LOG_LEVEL = logging.DEBUG
 
 
 def get_env_variable(var_name: str, default: Optional[str] = None) -> str:
@@ -233,7 +233,7 @@ class CustomSecurityManager(SupersetSecurityManager):
             me = res.json()
 
             # Uncomment the following line to inspect the returned user data
-            logger.debug(" user_data: %s", me)
+            # logger.debug(" user_data: %s", me)
 
             return {
                 "username": me["email"],
@@ -244,7 +244,7 @@ class CustomSecurityManager(SupersetSecurityManager):
             }
 
     def _oauth_calculate_user_roles(self, userinfo):
-        # Auth0 role_keys only — do not union AUTH_USER_REGISTRATION_ROLE.
+        # Auth0 role_keys only; do not union AUTH_USER_REGISTRATION_ROLE.
         roles = list(self.get_roles_from_keys(userinfo.get("role_keys") or []))
         if roles:
             return roles
@@ -254,7 +254,6 @@ class CustomSecurityManager(SupersetSecurityManager):
 
 # https://superset.apache.org/user-docs/6.0.0/configuration/configuring-superset/#mapping-oauth-groups-to-superset-roles
 AUTH_ROLES_SYNC_AT_LOGIN = True
-
 AUTH_ROLES_MAPPING = {
     "Admin": ["Admin"],
     "Member": ["Alpha"],

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -38,6 +38,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 
 logger = logging.getLogger()
 
+# Uncomment to enable debug logging
 LOG_LEVEL = logging.DEBUG
 
 
@@ -230,23 +231,30 @@ class CustomSecurityManager(SupersetSecurityManager):
                 logger.error("Failed to obtain user info.")
                 return
             me = res.json()
+
+            res = (
+                self.appbuilder.sm.oauth_remotes[provider]
+                .get(f"https://{AUTH0_DOMAIN}/api/v2/users/{me['sub']}/roles")
+                .json()
+            )
+            if res.raw.status != 200:
+                logger.error("Failed to obtain user info.")
+                return
+            roles = res.json()
+            logger.debug(" roles: %s", roles)
+
+            role_keys = [role["name"] for role in roles]
+            # TODO: Add logic to fetch roles from auth0 https://auth0.com/docs/api/management/v2/users/get-user-roles
+
             # Uncomment the following line to inspect the returned user data
             logger.debug(" user_data: %s", me)
-
-            # Auth0 returns a full name, but Superset expects first/last name
-            # We'll split the full name into two parts, but note that this is
-            # not robust since some people have multiple first or last names
-            # and naming conventions across the world vary (e.g. some cultures
-            # put the last name first).
-            name_parts = me["name"].rsplit(maxsplit=1)
-            first_name = name_parts[0]
-            last_name = name_parts[1] if len(name_parts) > 1 else ""
 
             return {
                 "username": me["email"],
                 "email": me["email"],
-                "first_name": first_name,
-                "last_name": last_name,
+                "first_name": me["given_name"],
+                "last_name": me["family_name"],
+                "role_keys": role_keys,
             }
 
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -243,6 +243,14 @@ class CustomSecurityManager(SupersetSecurityManager):
                 "role_keys": me.get("urn.gc.roles", []),
             }
 
+    def _oauth_calculate_user_roles(self, userinfo):
+        # Auth0 role_keys only — do not union AUTH_USER_REGISTRATION_ROLE.
+        roles = list(self.get_roles_from_keys(userinfo.get("role_keys") or []))
+        if roles:
+            return roles
+        public = self.find_role("Public")
+        return [public] if public else []
+
 
 # https://superset.apache.org/user-docs/6.0.0/configuration/configuring-superset/#mapping-oauth-groups-to-superset-roles
 AUTH_ROLES_SYNC_AT_LOGIN = True
@@ -254,9 +262,6 @@ AUTH_ROLES_MAPPING = {
     "SignedIn": ["Public"],
 }
 
-# Fallback user role if no mapping is found.
-USER_ROLE = get_env_variable("USER_ROLE", "Alpha")
-
 # Uses standard Superset authentication and authorization by default.
 # To use Auth0 instead, set the three AUTH0_* variables:
 AUTH0_DOMAIN = get_env_variable("AUTH0_DOMAIN", "")
@@ -265,7 +270,7 @@ if AUTH0_DOMAIN:
     AUTH_TYPE = AUTH_OAUTH
 
     AUTH_USER_REGISTRATION = True
-    AUTH_USER_REGISTRATION_ROLE = USER_ROLE
+    AUTH_USER_REGISTRATION_ROLE = "Public"
 
     OAUTH_PROVIDERS = [
         {

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -229,7 +229,7 @@ class CustomSecurityManager(SupersetSecurityManager):
                 return
             me = res.json()
             # Uncomment the following line to inspect the returned user data
-            logger.debug(" user_data: %s", me)
+            logger.info(" user_data: %s", me)
 
             # Auth0 returns a full name, but Superset expects first/last name
             # We'll split the full name into two parts, but note that this is


### PR DESCRIPTION
## Goal

Closes https://github.com/ConservationMetrics/superset-deployment/issues/57.

After a evening of wrestling with very sparse Superset AND auth0 documentation plus much debugging, I can't believe I actually got this working! :open_mouth: 

The lack of synchronization between GC (Landing Page and Explorer) and Superset roles is a major pain point for users! This PR solves that problem by not only reading the roles upon registration, but also synchronizing them every login. (This means no drift between Superset and GC roles.)

## What I changed and why

- Added `AUTH_ROLES_SYNC_AT_LOGIN` and `AUTH_ROLES_MAPPING` vars (set to our RBAC definitions)
- Falls back to Public if no Role is set (de-unionized).
- Removes `USER_ROLE` as we no longer need this.
- Added documentation including the necessary Post-Login Action that needs to be added to auth0 to add user roles to `/userinfo` response.
- While I was here, I noticed that Superset `/userinfo` returns first and last name, so I got rid of some unnecessary and not very robust code that split `name` into two parts to construct these.

## How I convinced myself this is right

By trying it, and through debug logs (now turned off).

To reproduce (can be done on Staging):

- Have a Guest account.
- Sign in to Superset (whether first time or account already existing).
- You will be assigned Gamma role. Log out.
- Change that account's role to Member.
- Sign in to Superset again.
- Now, that account will have Alpha role.

## What I'm not doing here

In `gc-deploy`, we will need to:

- Document the need to add the Roles Post-Login action
- Rip out `USER_ROLE` from one-click-app YAML definition (and adjust onboarding documentation)

EDIT: WIP branch here https://github.com/ConservationMetrics/gc-deploy/tree/rk/superset-rbac-sync-changes

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

I had Cursor generate docs, very minimal.