### PR TITLE
[auth0] Fall back to email if first and last names not found

### DIFF
--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -235,9 +235,10 @@ class CustomSecurityManager(SupersetSecurityManager):
             return {
                 "username": me["email"],
                 "email": me["email"],
-                "first_name": me.get("given_name")
-                or "",  # Auth0 will not return first (or last) name if users signed up with email and password instead of social login
-                "last_name": me.get("family_name") or "",
+                "first_name": me.get(
+                    "given_name", ""
+                ),  # Auth0 will not return first (or last) name if users signed up with email and password instead of social login
+                "last_name": me.get("family_name", ""),
                 "role_keys": me.get("urn.gc.roles", []),
             }
 

--- a/docker/pythonpath/superset_config.py
+++ b/docker/pythonpath/superset_config.py
@@ -235,8 +235,9 @@ class CustomSecurityManager(SupersetSecurityManager):
             return {
                 "username": me["email"],
                 "email": me["email"],
-                "first_name": me["given_name"],
-                "last_name": me["family_name"],
+                "first_name": me.get("given_name")
+                or "",  # Auth0 will not return first (or last) name if users signed up with email and password instead of social login
+                "last_name": me.get("family_name") or "",
                 "role_keys": me.get("urn.gc.roles", []),
             }
 


### PR DESCRIPTION
https://github.com/ConservationMetrics/superset-deployment/pull/64 introduced a change where we pull `given_name` and `family_name` from auth0 instead of trying to construct these from a full name string using a space delimiter. But I didn't think of the case where a user created an auth0 account with username and password, hence no `given_name` or `family_name` fields were set. This resulted in two users this morning reporting being unable to login to Superset.

This PR fixes that by setting the fallback to an empty string, which I confirmed works in Superset (see my comment https://github.com/ConservationMetrics/superset-deployment/pull/65#issuecomment-5169127424)